### PR TITLE
Support for RadioHead's RHReliableDatagram protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/S3ler/arduino-linux-abstraction.git
 [submodule "RadioHeadRpi"]
 	path = RadioHeadRpi
-	url = https://github.com/joelkoz/RadioHeadRpi.git
+	url = https://github.com/S3ler/RadioHeadRpi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/S3ler/arduino-linux-abstraction.git
 [submodule "RadioHeadRpi"]
 	path = RadioHeadRpi
-	url = https://github.com/S3ler/RadioHeadRpi.git
+	url = https://github.com/joelkoz/RadioHeadRpi.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,10 @@ set(RH_DATAGRAM_SRC_FILES
 	RadioHeadRpi/RHDatagram.cpp
 	RadioHeadRpi/RHGenericDriver.h
 	RadioHeadRpi/RHGenericDriver.cpp
+	RadioHeadRpi/RH_Serial.cpp
+	RadioHeadRpi/RHCRC.cpp
     RadioHeadRpi/RHutil/RasPi.cpp
+    RadioHeadRpi/RHutil/HardwareSerial.cpp
 	RHDatagramSocket.h
 	RHDatagramSocket.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,8 @@ set(RH_DATAGRAM_SRC_FILES
 	RadioHeadRpi/RHCRC.cpp
     RadioHeadRpi/RHutil/RasPi.cpp
     RadioHeadRpi/RHutil/HardwareSerial.cpp
-	RHDatagramSocket.h
-	RHDatagramSocket.cpp
+	RHReliableDatagramSocket.h
+	RHReliableDatagramSocket.cpp
 )
 
 add_library(lib-rh-datagram-socket ${RH_DATAGRAM_SRC_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,3 +81,20 @@ target_compile_definitions(example-lib-rh-nrf24-socket PRIVATE -DRASPBERRY_PI -D
 target_include_directories(example-lib-rh-nrf24-socket PRIVATE RadioHead RadioHead/RHutil)
 target_link_libraries(example-lib-rh-nrf24-socket lib-rh-nrf24-socket bcm2835)
  
+
+set(RH_DATAGRAM_SRC_FILES
+    RadioHeadRpi/RHReliableDatagram.h
+    RadioHeadRpi/RHReliableDatagram.cpp
+	RadioHeadRpi/RHDatagram.h
+	RadioHeadRpi/RHDatagram.cpp
+	RadioHeadRpi/RHGenericDriver.h
+	RadioHeadRpi/RHGenericDriver.cpp
+    RadioHeadRpi/RHutil/RasPi.cpp
+	RHDatagramSocket.h
+	RHDatagramSocket.cpp
+)
+
+add_library(lib-rh-datagram-socket ${RH_DATAGRAM_SRC_FILES})
+target_compile_definitions(lib-rh-datagram-socket PRIVATE -DRASPBERRY_PI -DBCM2835_NO_DELAY_COMPATIBILITY)
+target_include_directories(lib-rh-datagram-socket PRIVATE RadioHeadRPi RadioHeadRPi/RHutil)
+target_link_libraries(lib-rh-datagram-socket bcm2835)

--- a/RHDatagramSocket.cpp
+++ b/RHDatagramSocket.cpp
@@ -1,0 +1,103 @@
+#include "RHDatagramSocket.h"
+
+
+bool RHDatagramSocket::begin() {
+
+    if (this->logger == nullptr) {
+        return false;
+    }
+
+    if (this->mqttSnMessageHandler == nullptr) {
+        logger->log("No mqttSnMessageHandler defined", 0);
+        return false;
+    }
+
+    if (this->manager == nullptr) {
+        logger->log("No RHDatagram manager defined", 0);
+        return false;
+    }
+
+    own_address = device_address(manager->thisAddress(), 0, 0, 0, 0, 0);
+    broadcast_address = device_address(RH_BROADCAST_ADDRESS, 0, 0, 0, 0, 0);
+
+    if (!manager->init()) {
+        return false;
+    }
+
+    return true;
+}
+
+
+void RHDatagramSocket::setManager(RHDatagram* manager) {
+    this->manager = manager;
+}
+
+
+void RHDatagramSocket::setLogger(LoggerInterface *logger) {
+    this->logger = logger;
+}
+
+
+void RHDatagramSocket::setMqttSnMessageHandler(MqttSnMessageHandler *mqttSnMessageHandler) {
+    this->mqttSnMessageHandler = mqttSnMessageHandler;
+}
+
+
+device_address *RHDatagramSocket::getBroadcastAddress() {
+    return &broadcast_address;
+}
+
+
+device_address *RHDatagramSocket::getAddress() {
+    return &own_address;
+}
+
+
+uint8_t RHDatagramSocket::getMaximumMessageLength() {
+    return RH_MAX_MESSAGE_LEN;
+}
+
+
+bool RHDatagramSocket::send(device_address *destination, uint8_t *bytes, uint16_t bytes_len) {
+    return send(destination, bytes, bytes_len, UINT8_MAX);
+}
+
+
+bool RHDatagramSocket::send(device_address *destination, uint8_t *bytes, uint16_t bytes_len, uint8_t signal_strength) {
+    bool sendOk = manager->sendto(bytes, bytes_len, destination->bytes[0]);
+    manager->waitPacketSent();
+    manager->available(); // put it back to receive mode
+    return sendOk;
+}
+
+
+
+bool RHDatagramSocket::loop() {
+
+    if (manager->available()) {
+
+        device_address receive_address;
+        memset(&receive_address, 0x0, sizeof(device_address));
+
+        uint8_t receive_buffer[RH_MAX_MESSAGE_LEN];
+        memset(&receive_buffer, 0x0, RH_MAX_MESSAGE_LEN);
+
+        uint8_t receive_buffer_len = sizeof(receive_buffer);
+
+        if (manager->recvfrom(receive_buffer, &receive_buffer_len, &receive_address.bytes[0])) {
+
+            if (mqttSnMessageHandler != nullptr) {
+                mqttSnMessageHandler->receiveData(&receive_address, receive_buffer);
+            }
+
+            // if (transmissionProtocolUartBridge != nullptr) {
+            //     transmissionProtocolUartBridge->receiveData(&receive_address, receive_buffer, receive_buffer_len);
+            // }
+
+        }
+    }
+
+    return true;
+}
+
+

--- a/RHDatagramSocket.cpp
+++ b/RHDatagramSocket.cpp
@@ -24,7 +24,14 @@ bool RHDatagramSocket::begin() {
         return false;
     }
 
-    return true;
+    logger->log("MQTT-SN incomming datagram socket waiting for initial connection...", 2);
+    if (manager->waitAvailableTimeout(this->msConnectTimeout)) {
+        this->mqttSnMessageHandler->notify_socket_connected();
+        return true;
+    }
+
+    logger->log("Incomming MQTT-SN connection timed out.", 0);
+    return false;
 }
 
 

--- a/RHDatagramSocket.h
+++ b/RHDatagramSocket.h
@@ -13,6 +13,12 @@
 #include "MqttSnMessageHandler.h"
 #include "SocketInterface.h"
 
+/**
+ * A socket compatible with RadioHead's RHDatagram manager. Note that unless
+ * you have pre-existing code, you should use RHReliableDatagramSocket instead
+ * as it is also compatible with normal RHDatagram's on the other end, as it can
+ * have "reliable" mode turned on or off.
+ */
 class RHDatagramSocket : public SocketInterface {
 
 public:

--- a/RHDatagramSocket.h
+++ b/RHDatagramSocket.h
@@ -36,6 +36,8 @@ public:
 
     void setMqttSnMessageHandler(MqttSnMessageHandler *mqttSnMessageHandler) override;
 
+    void setConnectionTimeout(uint16_t timeoutInMillis) { this-> msConnectTimeout = timeoutInMillis; }
+
 protected:
     RHDatagram* manager;
 
@@ -45,6 +47,8 @@ protected:
     LoggerInterface *logger = nullptr;
 
     MqttSnMessageHandler *mqttSnMessageHandler = nullptr;
+
+    uint16_t msConnectTimeout = 30000;
 
 };
 

--- a/RHDatagramSocket.h
+++ b/RHDatagramSocket.h
@@ -13,7 +13,7 @@
 #include "MqttSnMessageHandler.h"
 #include "SocketInterface.h"
 
-class RHDatagramSocket : SocketInterface {
+class RHDatagramSocket : public SocketInterface {
 
 public:
     bool begin() override;

--- a/RHDatagramSocket.h
+++ b/RHDatagramSocket.h
@@ -1,0 +1,51 @@
+/*
+* The MIT License (MIT)
+*
+* Copyright (C) 2018 Gabriel Nikol
+* Refactored for use in Gateway 2020 by Joel Kozikowski
+*/
+
+#ifndef RADIOHEADSOCKET__RHDATAGRAMSOCKET_H
+#define RADIOHEADSOCKET__RHDATAGRAMSOCKET_H
+
+#include <RHDatagram.h>
+
+#include "MqttSnMessageHandler.h"
+#include "SocketInterface.h"
+
+class RHDatagramSocket : SocketInterface {
+
+public:
+    bool begin() override;
+
+    void setManager(RHDatagram* manager);
+
+    void setLogger(LoggerInterface *logger) override;
+
+    device_address *getBroadcastAddress() override;
+
+    device_address *getAddress() override;
+
+    uint8_t getMaximumMessageLength() override;
+
+    bool send(device_address *destination, uint8_t *bytes, uint16_t bytes_len);
+
+    bool send(device_address *destination, uint8_t *bytes, uint16_t bytes_len, uint8_t signal_strength);
+
+    bool loop() override;
+
+    void setMqttSnMessageHandler(MqttSnMessageHandler *mqttSnMessageHandler) override;
+
+protected:
+    RHDatagram* manager;
+
+    device_address own_address;
+    device_address broadcast_address;
+
+    LoggerInterface *logger = nullptr;
+
+    MqttSnMessageHandler *mqttSnMessageHandler = nullptr;
+
+};
+
+#endif // RADIOHEADSOCKET__RHDATAGRAMSOCKET_H

--- a/RHReliableDatagramSocket.cpp
+++ b/RHReliableDatagramSocket.cpp
@@ -1,0 +1,133 @@
+#include "RHReliableDatagramSocket.h"
+
+
+bool RHReliableDatagramSocket::begin() {
+
+    if (this->logger == nullptr) {
+        return false;
+    }
+
+    if (this->mqttSnMessageHandler == nullptr) {
+        logger->log("No mqttSnMessageHandler defined", 0);
+        return false;
+    }
+
+    if (this->manager == nullptr) {
+        logger->log("No RHDatagram manager defined", 0);
+        return false;
+    }
+
+    own_address = device_address(manager->thisAddress(), 0, 0, 0, 0, 0);
+    broadcast_address = device_address(RH_BROADCAST_ADDRESS, 0, 0, 0, 0, 0);
+
+    if (!manager->init()) {
+        return false;
+    }
+
+    logger->log("MQTT-SN incomming datagram socket waiting for initial connection...", 2);
+    while (true) {
+        if (manager->waitAvailableTimeout(this->msConnectTimeout)) {
+            this->mqttSnMessageHandler->notify_socket_connected();
+            return true;
+        }
+        else {
+            logger->log("No client connection - wait timed out. Trying again...", 1);
+        }
+    }
+}
+
+
+void RHReliableDatagramSocket::setManager(RHReliableDatagram* manager) {
+    this->manager = manager;
+}
+
+
+void RHReliableDatagramSocket::setLogger(LoggerInterface *logger) {
+    this->logger = logger;
+}
+
+
+void RHReliableDatagramSocket::setMqttSnMessageHandler(MqttSnMessageHandler *mqttSnMessageHandler) {
+    this->mqttSnMessageHandler = mqttSnMessageHandler;
+}
+
+
+device_address *RHReliableDatagramSocket::getBroadcastAddress() {
+    return &broadcast_address;
+}
+
+
+device_address *RHReliableDatagramSocket::getAddress() {
+    return &own_address;
+}
+
+
+uint8_t RHReliableDatagramSocket::getMaximumMessageLength() {
+    return RH_MAX_MESSAGE_LEN;
+}
+
+
+bool RHReliableDatagramSocket::send(device_address *destination, uint8_t *bytes, uint16_t bytes_len) {
+    return send(destination, bytes, bytes_len, UINT8_MAX);
+}
+
+
+void RHReliableDatagramSocket::setReliableProtocol(bool isReliable) {
+    this->reliable = isReliable;
+}
+
+
+bool RHReliableDatagramSocket::send(device_address *destination, uint8_t *bytes, uint16_t bytes_len, uint8_t signal_strength) {
+    bool sendOk;
+
+    if (reliable) {
+       sendOk = manager->sendtoWait(bytes, bytes_len, destination->bytes[0]);
+    }
+    else {
+       sendOk = manager->sendto(bytes, bytes_len, destination->bytes[0]);
+    }
+    manager->waitPacketSent();
+    manager->available(); // put it back to receive mode
+    return sendOk;
+}
+
+
+
+bool RHReliableDatagramSocket::receive(device_address *source, uint8_t *bytes, uint16_t bytes_len) {
+   uint8_t len = bytes_len;
+   if (reliable) {
+      return manager->recvfromAck(bytes, &len, &(source->bytes[0]));
+   }
+   else {
+      return manager->recvfrom(bytes, &len, &(source->bytes[0]));
+   }
+}
+
+
+bool RHReliableDatagramSocket::loop() {
+
+    if (manager->available()) {
+
+        device_address receive_address;
+        memset(&receive_address, 0x0, sizeof(device_address));
+
+        uint8_t receive_buffer[RH_MAX_MESSAGE_LEN];
+        memset(&receive_buffer, 0x0, RH_MAX_MESSAGE_LEN);
+
+        uint8_t receive_buffer_len = sizeof(receive_buffer);
+
+        if (receive(&receive_address, receive_buffer, receive_buffer_len)) {
+
+            if (mqttSnMessageHandler != nullptr) {
+                mqttSnMessageHandler->receiveData(&receive_address, receive_buffer);
+            }
+
+            // if (transmissionProtocolUartBridge != nullptr) {
+            //     transmissionProtocolUartBridge->receiveData(&receive_address, receive_buffer, receive_buffer_len);
+            // }
+
+        }
+    }
+
+    return true;
+}

--- a/RHReliableDatagramSocket.h
+++ b/RHReliableDatagramSocket.h
@@ -1,0 +1,75 @@
+/*
+* The MIT License (MIT)
+*
+* Copyright (C) 2018 Gabriel Nikol
+* Refactored for use in Gateway 2020 by Joel Kozikowski
+*/
+
+#ifndef RADIOHEADSOCKET__RHRELIABLEDATAGRAMSOCKET_H
+#define RADIOHEADSOCKET__RHDRELIABLEATAGRAMSOCKET_H
+
+#include <RHReliableDatagram.h>
+
+#include "MqttSnMessageHandler.h"
+#include "SocketInterface.h"
+
+/**
+ * A socket compatible with RadioHead's RHDatagram and RHReliableDatagram
+ * managers on the other end.  An RHReliableDatagram manager is necessary
+ * to be assigned to this class via setManager(), Note that the
+ * "reliable" protocol used by RHReliableDatagram can be disabled by
+ * calling setReliableProtocol().
+ */
+class RHReliableDatagramSocket : public SocketInterface {
+
+public:
+    bool begin() override;
+
+    void setManager(RHReliableDatagram* manager);
+
+    void setLogger(LoggerInterface *logger) override;
+
+    device_address *getBroadcastAddress() override;
+
+    device_address *getAddress() override;
+
+    uint8_t getMaximumMessageLength() override;
+
+    bool send(device_address *destination, uint8_t *bytes, uint16_t bytes_len);
+
+    bool send(device_address *destination, uint8_t *bytes, uint16_t bytes_len, uint8_t signal_strength) override;
+
+    virtual bool receive(device_address *source, uint8_t *bytes, uint16_t bytes_len);
+
+    bool loop() override;
+
+    void setMqttSnMessageHandler(MqttSnMessageHandler *mqttSnMessageHandler) override;
+
+    // Set the timeout this socket will wait for an initial connection
+    void setConnectionTimeout(uint16_t timeoutInMillis) { this-> msConnectTimeout = timeoutInMillis; }
+
+    /**
+     * Sets whether or not to use RadioHead's "reliable" acknowledged protocol, or its 
+     * normal one.  The default is "not reliable"
+     */
+    void setReliableProtocol(bool isReliable);
+
+    bool isReliable() { return reliable; }
+
+protected:
+    RHReliableDatagram* manager;
+
+    device_address own_address;
+    device_address broadcast_address;
+
+    LoggerInterface *logger = nullptr;
+
+    MqttSnMessageHandler *mqttSnMessageHandler = nullptr;
+
+    uint16_t msConnectTimeout = 10000;
+
+    bool reliable = true;
+
+};
+
+#endif // RADIOHEADSOCKET__RHDATAGRAMSOCKET_H

--- a/RadioHead/RHutil/RasPi.cpp
+++ b/RadioHead/RHutil/RasPi.cpp
@@ -105,6 +105,10 @@ unsigned long millis()
   return difference;
 }
 
+void resetTimerValue() {
+    gettimeofday(&RHStartTime, NULL);
+}
+
 void delay (unsigned long ms)
 {
   //Implement Delay function

--- a/RadioHead/RHutil/RasPi.h
+++ b/RadioHead/RHutil/RasPi.h
@@ -68,6 +68,8 @@ void digitalWrite(unsigned char pin, unsigned char value);
 
 unsigned long millis();
 
+extern void resetTimerValue();
+
 //#if !defined(BCM2835_H)
 void delay (unsigned long delay);
 //#endif

--- a/lib/LoggerInterface.cpp
+++ b/lib/LoggerInterface.cpp
@@ -16,19 +16,15 @@ void LoggerInterface::log(const char *msg, uint8_t log_lvl) {
     if (log_lvl > current_log_lvl) {
         return;
     }
-#if defined(Arduino_h)
-    Serial.println();
-#else
-    std::cout << std::endl;
-#endif
     char millis_buffer[26];
     sprintf(millis_buffer, "%ld", millis());
 #if defined(Arduino_h)
     Serial.print(millis_buffer);
     Serial.print(": ");
     Serial.print(msg);
+    Serial.println();
 #else
-    std::cout << millis_buffer << ": " << msg << std::flush;
+    std::cout << millis_buffer << ": " << msg << std::endl << std::flush;
 #endif
 
 }


### PR DESCRIPTION
This PR is a sub-module modification for the primary changes made in linux-mqtt-sn-gateway.

The primary purpose of this PR is to add support for using RadioHead's serial protocol on a serial port via the new RHSerialSocket class. To support this, RHReliableDatagramSocket and RHDatagramSocket were also created. Unless you pre-existing code that requires RHDatagram as your manager, RHReliableDatagramSocket is preffered, as it can talk to both protocols by simply switching on/off "reliable" mode.

The Transmission protocol identifier RH_SERIAL was added to the list identifiers that can be passed to CMake.

This PR was made for and tested on my primary use case: an MQTT-SN gateway on a Raspberry Pi. As part of this, the Gateway code made more robust and fault tolerant. Terminating a thread due to an error condition now throws the catchable exception LinuxSystem::ThreadTerminated. In response to that, the gateway now shuts down gracefully when sockets are lost or endpoints are not set up correctly. Finally, I added some logger messages to the early begin() and init() procedures to help diagnose setup errors, and I cleaned up a compiler warnings in the core.